### PR TITLE
Apply Material 3 expressive design tokens

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,26 +8,40 @@
     <!-- FONTS & ICONS -->
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=EB+Garamond:wght@400;700&family=Inter:wght@400;500;600&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=EB+Garamond:wght@400;700&family=Roboto+Flex:opsz,wght@8..144,400;8..144,700&display=swap" rel="stylesheet">
     <script src="https://unpkg.com/@phosphor-icons/web" defer></script>
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.2/dist/confetti.browser.min.js" defer></script>
 
     <style>
         :root {
-            --bg: #1a1c20;
-            --surface: #25282e;
-            --fg: #e0e2e8;
-            --fg-muted: #8c919f;
-            --fg-subtle: #5c616c;
-            --accent: #d4af37;
-            --accent-light: #e6c86e;
+            /* Material 3 Expressive tokens */
+            --md-sys-color-primary: #ff006e;
+            --md-sys-color-on-primary: #ffffff;
+            --md-sys-color-surface: #1c1b1f;
+            --md-sys-color-surface-container-high: #2b2930;
+            --md-sys-color-on-surface: #e6e1e5;
+            --md-sys-color-outline: #938f99;
+            --md-sys-shape-corner-small: 4px;
+            --md-sys-shape-corner-medium: 8px;
+            --md-sys-typescale-title-medium-size: 1rem;
+            --md-sys-typescale-title-medium-weight: 700;
+            --md-sys-typescale-title-medium-line-height: 1.5;
+
+            /* Existing theme mapped to M3 tokens */
+            --bg: var(--md-sys-color-surface);
+            --surface: var(--md-sys-color-surface-container-high);
+            --fg: var(--md-sys-color-on-surface);
+            --fg-muted: #c9c5cb;
+            --fg-subtle: #8e8d92;
+            --accent: var(--md-sys-color-primary);
+            --accent-light: color-mix(in srgb,var(--md-sys-color-primary) 90%, white);
             --danger: #e57373;
             --cheat: #4a4e59;
             --parchment-bg: #fdf6e3;
             --parchment-fg: #5d4037;
             --parchment-border: #d8c8a8;
-            --round: 8px;
-            --font-body: 'Inter', system-ui, -apple-system, Segoe UI, Roboto;
+            --round: var(--md-sys-shape-corner-medium);
+            --font-body: 'Roboto Flex', system-ui, -apple-system, Segoe UI, Roboto;
             --font-heading: 'EB Garamond', serif;
         }
 
@@ -58,10 +72,13 @@
         h1, h2, h3, h4 {
             font-family: var(--font-heading);
             margin: 0 0 .6em;
-            font-weight: 700;
+            font-weight: var(--md-sys-typescale-title-medium-weight);
             color: var(--accent-light);
         }
-        h3 { font-size: 1.5rem; }
+        h3 {
+            font-size: var(--md-sys-typescale-title-medium-size);
+            line-height: var(--md-sys-typescale-title-medium-line-height);
+        }
 
         /* FORM ELEMENTS */
         label {
@@ -101,21 +118,25 @@
         button {
             cursor: pointer;
             background: var(--accent);
-            color: var(--bg);
+            color: var(--md-sys-color-on-primary);
             border: none;
             font-size: 1rem;
             padding: .8em;
             border-radius: var(--round);
             font-weight: 600;
-            transition: background-color 0.2s;
+            box-shadow: 0 1px 2px rgb(0 0 0 / 0.3);
+            transition: background-color 0.2s, box-shadow 0.2s;
         }
-        button:hover { background: var(--accent-light); }
+        button:hover { background: color-mix(in srgb,var(--accent) 90%, black); }
         button.secondary {
             background: var(--surface);
             color: var(--fg-muted);
             border: 1px solid var(--fg-subtle);
         }
-        button.secondary:hover { background: #3a3d44; color: var(--fg); }
+        button.secondary:hover {
+            background: color-mix(in srgb,var(--surface) 90%, white);
+            color: var(--fg);
+        }
         button.icon-btn {
             background: transparent;
             border: none;
@@ -123,8 +144,9 @@
             color: var(--fg-muted);
             width: auto;
             line-height: 0;
+            border-radius: var(--round);
         }
-        button.icon-btn:hover { color: var(--accent-light); }
+        button.icon-btn:hover { color: var(--accent-light); background: color-mix(in srgb,var(--surface) 90%, white); }
         button.icon-btn i { font-size: 1.5rem; }
 
         /* GRID OF SQUARES */
@@ -138,12 +160,14 @@
             position: relative;
             padding-top: 100%;
             border: 2px solid var(--fg-subtle);
-            border-radius: 4px;
+            border-radius: var(--md-sys-shape-corner-small);
             user-select: none;
             transition: transform 0.1s, box-shadow 0.2s;
+            background: var(--surface);
         }
         .box:hover {
             transform: scale(1.05);
+            background: color-mix(in srgb,var(--surface) 90%, white);
         }
         .box span {
             position: absolute;
@@ -183,6 +207,7 @@
         }
         .box.filled {
             border-color: var(--accent);
+            background: var(--accent);
         }
         .box.filled .filler {
             transform: scale(1.5);
@@ -226,7 +251,7 @@
         .dialog {
             background: var(--parchment-bg);
             color: var(--parchment-fg);
-            border-radius: 4px;
+            border-radius: var(--round);
             padding: 24px;
             max-width: 90%;
             width: 420px;


### PR DESCRIPTION
## Summary
- integrate Material 3 Expressive color and type tokens
- swap Inter for Roboto Flex
- style buttons and boxes with Material 3 inspired look
- tweak dialogs and headings

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685406d8c15c8325aafcb880afa0c85f