### PR TITLE
Handle missed days correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,6 @@ All notable changes to this project will be documented below.
 - Add README with changelog.
 - Improve README with a detailed explanation of how `index.html` works.
 - Plan future enhancements such as mobile optimizations, data export/import improvements, and additional quests.
+- Fix grid progress to skip days with no entry.
+- Resolve bug where completing a day after skipping filled the wrong square.
+- Fix rest day showing one day late due to timezone parsing.

--- a/index.html
+++ b/index.html
@@ -420,7 +420,8 @@ function render() {
     if (DEBUG) app.appendChild(debugBar());
 
     const td = todayDate();
-    app.appendChild(el("div", "todayLabel", `${weekdayEs(td.getDay())}`));
+    const label = weekdayEs(td.getDay());
+    app.appendChild(el("div", "todayLabel", label));
 
     if (isCheat(td)) {
         app.appendChild(el("div", "banner", t('cheat_banner')));
@@ -443,26 +444,29 @@ function render() {
 function buildGrid() {
     const g = el("div", "grid");
     const total = state.quest === 1 ? 21 : 60;
-    let progress = 0;
+    // Parse start date in local timezone to avoid DST offsets
+    const start = new Date(state.startDate + 'T00:00');
+    const today = todayStr();
+
     for (let i = 0; i < total; i++) {
-        const wday = (state.startWeekday + i) % 7;
-        const cheat = wday === state.cheatDay;
+        const dayDate = new Date(start.getTime() + i * oneDay);
+        const dayStr = dayDate.toISOString().slice(0, 10);
+        const cheat = dayDate.getDay() === state.cheatDay;
         const b = el("div", "box" + (cheat ? " cheat" : ""));
-        
+
         const content = cheat ? '🍇' : i + 1;
         b.appendChild(el("span", "", content));
-        
+
         if (!cheat) {
-            if (progress < state.entries.length) {
+            if (state.entries.some(e => e.date === dayStr)) {
                 b.classList.add("filled");
                 const svg = document.createElementNS("http://www.w3.org/2000/svg", "svg");
                 svg.setAttribute("class", "fill-svg");
                 svg.innerHTML = `<rect class="filler" width="100%" height="100%"/>`;
                 b.prepend(svg);
-            } else if (progress === state.entries.length && !isDone()) {
+            } else if (dayStr === today && !isDone()) {
                 b.classList.add("today");
             }
-            progress++;
         }
         g.appendChild(b);
     }
@@ -594,7 +598,10 @@ function modal(html) {
     m.innerHTML = `<div class="dialog">${html}</div>`;
     document.body.appendChild(m);
 }
-function closeModal() { $("#modal")?.remove(); }
+function closeModal() {
+    const modalEl = $("#modal");
+    if (modalEl) modalEl.remove();
+}
 
 function openHelp(i) {
     const ev = evidences[i].es;
@@ -701,7 +708,7 @@ function importData() {
                     save();
                     render();
                 } else { alert("Archivo de datos inválido."); }
-            } catch { alert("No se pudo leer el archivo."); }
+            } catch (err) { alert("No se pudo leer el archivo."); }
         };
         r.readAsText(f);
     };


### PR DESCRIPTION
## Summary
- fix skipped-day logic so completed squares match entry dates
- fix rest day offset due to timezone issue
- document bug fix in the changelog
- patch syntax mistakes that broke script execution

## Testing
- `node - <<'EOF'
const fs=require('fs');const esprima=require('esprima');
const code=fs.readFileSync('script_noscript.js','utf8');
try{esprima.parseScript(code,{ecmaVersion:2020});console.log('ok');}catch(e){console.log('err',e.message,'line',e.lineNumber);} 
EOF`


------
https://chatgpt.com/codex/tasks/task_e_685404c8834c8325ac02bee9e81797f5